### PR TITLE
Run beautiful_output with python3 strictly

### DIFF
--- a/callback_plugins/beautiful_output.py
+++ b/callback_plugins/beautiful_output.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # MIT License


### PR DESCRIPTION
You will never know if someone crazy would set the default Python
version to 2.x instead.
