### PR TITLE
Move `bluetuith-bin` to the AUR section

### DIFF
--- a/roles/ags/tasks/Archlinux.yml
+++ b/roles/ags/tasks/Archlinux.yml
@@ -9,6 +9,7 @@
       become: false
       loop:
         - aylurs-gtk-shell-git
+        - bluetuith-bin
         - bun-bin
         - matugen-bin
         - wayshot
@@ -25,7 +26,6 @@
         - fd
         - brightnessctl
         - gnome-bluetooth-3.0
-        - bluetuith-bin
         - libdbusmenu-gtk3
         - libnotify
         - libsoup3


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`bluetuith-bin` isn't in the official Arch repos, which means we can't just use `pacman` to install it. This PR fixes it by moving it to the AUR section.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Fixes: #31

#### Is it ready for merging, or does it need work?
Yes, it is ready for merging.