### PR TITLE
Tweaks for the power menu

### DIFF
--- a/roles/ags/files/ags/lib/icons.ts
+++ b/roles/ags/files/ags/lib/icons.ts
@@ -107,6 +107,7 @@ export default {
         reboot: "system-reboot-symbolic",
         logout: "system-log-out-symbolic",
         shutdown: "system-shutdown-symbolic",
+        lock: "system-lock-screen-symbolic",
     },
     recorder: {
         recording: "media-record-symbolic",

--- a/roles/ags/files/ags/options.ts
+++ b/roles/ags/files/ags/options.ts
@@ -178,6 +178,7 @@ const options = mkOptions(OPTIONS, {
         reboot: opt("systemctl reboot"),
         logout: opt("pkill Hyprland"),
         shutdown: opt("shutdown now"),
+        lock: opt("sh -c 'pidof hyprlock || hyprlock'"),
         layout: opt<"line" | "box">("line"),
         labels: opt(true),
     },

--- a/roles/ags/files/ags/service/powermenu.ts
+++ b/roles/ags/files/ags/service/powermenu.ts
@@ -1,8 +1,8 @@
 import options from "options"
 
-const { sleep, reboot, logout, shutdown } = options.powermenu
+const { sleep, reboot, logout, shutdown, lock } = options.powermenu
 
-export type Action = "sleep" | "reboot" | "logout" | "shutdown"
+export type Action = "sleep" | "reboot" | "logout" | "shutdown" | "lock"
 
 class PowerMenu extends Service {
     static {
@@ -23,6 +23,7 @@ class PowerMenu extends Service {
             reboot: [reboot.value, "Reboot"],
             logout: [logout.value, "Log Out"],
             shutdown: [shutdown.value, "Shutdown"],
+            lock: [lock.value, "Lock"],
         }[action]
 
         this.notify("cmd")

--- a/roles/ags/files/ags/widget/keybinds/data/shortcuts.ts
+++ b/roles/ags/files/ags/widget/keybinds/data/shortcuts.ts
@@ -54,6 +54,14 @@ const column2 = [
     ],
     appeartick: 2
   },
+  {
+    icon: '',
+    name: 'Session Shortcuts',
+    binds: [
+      { keys: ['⌘', '+', 'L'], action: 'Lock session' },
+    ],
+    appeartick: 2
+  },
 ]
 
 // COLUMN3

--- a/roles/ags/files/ags/widget/powermenu/PowerMenu.ts
+++ b/roles/ags/files/ags/widget/powermenu/PowerMenu.ts
@@ -37,6 +37,7 @@ export default () => PopupWindow({
                     SysButton("logout", "Log Out"),
                     SysButton("reboot", "Reboot"),
                     SysButton("sleep", "Sleep"),
+                    SysButton("lock", "Lock"),
                 ]
                 case "box": return [
                     Widget.Box(
@@ -48,6 +49,10 @@ export default () => PopupWindow({
                         { vertical: true },
                         SysButton("reboot", "Reboot"),
                         SysButton("sleep", "Sleep"),
+                    ),
+                    Widget.Box(
+                        { vertical: true },
+                        SysButton("lock", "Lock"),
                     ),
                 ]
             }

--- a/roles/ags/files/ags/widget/powermenu/PowerMenu.ts
+++ b/roles/ags/files/ags/widget/powermenu/PowerMenu.ts
@@ -34,25 +34,25 @@ export default () => PopupWindow({
             switch (layout) {
                 case "line": return [
                     SysButton("shutdown", "Shutdown"),
-                    SysButton("logout", "Log Out"),
                     SysButton("reboot", "Reboot"),
                     SysButton("sleep", "Sleep"),
+                    SysButton("logout", "Log Out"),
                     SysButton("lock", "Lock"),
                 ]
                 case "box": return [
                     Widget.Box(
                         { vertical: true },
                         SysButton("shutdown", "Shutdown"),
-                        SysButton("logout", "Log Out"),
+                        SysButton("lock", "Lock"),
                     ),
                     Widget.Box(
                         { vertical: true },
                         SysButton("reboot", "Reboot"),
-                        SysButton("sleep", "Sleep"),
+                        SysButton("logout", "Log Out"),
                     ),
                     Widget.Box(
                         { vertical: true },
-                        SysButton("lock", "Lock"),
+                        SysButton("sleep", "Sleep"),
                     ),
                 ]
             }

--- a/roles/hyprland/files/hypr/config/keybindings/default.conf
+++ b/roles/hyprland/files/hypr/config/keybindings/default.conf
@@ -6,6 +6,7 @@
 # Super key
 $mainMod = SUPER # Sets "Windows" key as main modifier
 
+bind = $mainMod, L, exec, $lock_cmd
 bind = $mainMod, RETURN, exec, $terminal
 bind = $mainMod SHIFT, M, exit,
 bind = $mainMod, B, exec, $browser

--- a/roles/hyprland/files/hypr/config/programs/default.conf
+++ b/roles/hyprland/files/hypr/config/programs/default.conf
@@ -3,6 +3,7 @@
 # name: "Default"
 # -----------------------------------------------------
 
+$lock_cmd = pidof hyprlock || hyprlock       # taken from hypridle.conf
 $terminal = kitty
 $fileManager = nautilus
 $browser = zen-browser


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Basically introduces a new keybind to lock the session (runs `hyprlock` in the same way as `hypridle` does).

There used to be a proposal for reloading AGS too but it was too problematic to implement unlike the keybind - AGS would freeze for a good 30 seconds before finally reloading! - despite using the exact same command so I nuked it out altogether.

Also reorders the power menu to make it look less scrambled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
You can drop the reordering of the power menu if you want, it's just for visual accessibility.

#### Is it ready for merging, or does it need work?
Yes, it is ready for merging.
