### PR TITLE
Set Hypridle to suspend instead of hibernate

### DIFF
--- a/roles/hyprland/files/hypr/hypridle.conf
+++ b/roles/hyprland/files/hypr/hypridle.conf
@@ -30,5 +30,5 @@ listener {
 
 listener {
     timeout = 190                               # 3s
-    on-timeout = ~/.config/hypr/scripts/check_fullscreen.sh hibernate  # trigger hibernate when timeout has passed
+    on-timeout = ~/.config/hypr/scripts/check_fullscreen.sh suspend  # trigger suspend when timeout has passed
 }

--- a/roles/hyprland/files/hypr/scripts/check_fullscreen.sh
+++ b/roles/hyprland/files/hypr/scripts/check_fullscreen.sh
@@ -95,12 +95,12 @@ case "$1" in
             hyprctl dispatch dpms on
         fi
         ;;
-    "hibernate")
+    "suspend")
     # Trigger hibernate
     if check_fullscreen; then
         exit 0
     else
-        systemctl hibernate
+        systemctl suspend
     fi
     ;;
 esac

--- a/roles/hyprland/files/hypr/scripts/check_fullscreen.sh
+++ b/roles/hyprland/files/hypr/scripts/check_fullscreen.sh
@@ -96,7 +96,7 @@ case "$1" in
         fi
         ;;
     "suspend")
-    # Trigger hibernate
+    # Trigger suppend
     if check_fullscreen; then
         exit 0
     else


### PR DESCRIPTION
Hypridle is set to hibernate (systemctl hibernate) instead of sleep
(systemctl suspend), which causes systems without hibernation set up
to shut down instead.

Fixes: #37

#### Describe your PR, what does it fix/add?
It fixes idle behavior after the timeout has been passed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
N/A

#### Is it ready for merging, or does it need work?
Yes, it is ready for merging.

