### PR TITLE
Some updates to the icon and cursor themes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -33,6 +33,8 @@ icons:
   cursor_icons_theme: Bibata-Modern-Ice
   # available cursor sizes: 16 20 22 24 28 32 40 48 56 64 72 80 88 96
   cursor_icons_size: 24
+  system_icons_package: tela-circle-icon-theme-all # AUR ONLY CURRENTLY
+  system_icons_theme: Tela-circle-pink
   
 pacman:
   parallel_downloads: 5 # Adjust as needed

--- a/roles/ags/tasks/main.yml
+++ b/roles/ags/tasks/main.yml
@@ -27,6 +27,17 @@
       loop:
         - { src: 'config.toml.j2', dest: 'config.toml' }
 
+    - name: "Ags Greetd Configuration | Set up the environment"
+      ansible.builtin.template:
+        src: "{{ item.src }}"
+        dest: "/etc/{{ item.dest }}"
+        backup: yes
+        owner: "root"
+        group: "root"
+      become: true
+      loop:
+        - { src: 'environment.j2', dest: 'environment' }
+
     - name: Enable services
       systemd:
         name: "{{ item }}"

--- a/roles/ags/templates/environment.j2
+++ b/roles/ags/templates/environment.j2
@@ -1,0 +1,6 @@
+#
+# This file is parsed by pam_env module
+#
+# Syntax: simple "KEY=VAL" pairs on separate lines
+#
+XCURSOR_THEME={{ icons.cursor_icons_theme }}

--- a/roles/hyprland/files/hypr/config/autostart.conf
+++ b/roles/hyprland/files/hypr/config/autostart.conf
@@ -14,6 +14,9 @@ exec-once = ags
 exec-once = gsettings set org.gnome.desktop.interface cursor-theme Bibata-Modern-Ice
 exec-once = hyprctl setcursor Bibata-Modern-Ice 24
 
+# Set up icon theme
+exec-once = gsettings set org.gnome.desktop.interface icon-theme Tela-circle-pink
+
 # initilize hyprpaper
 exec-once = hyprpaper
 

--- a/roles/hyprland/tasks/Archlinux.yml
+++ b/roles/hyprland/tasks/Archlinux.yml
@@ -31,6 +31,7 @@
       become: false
       loop:
         - "{{ icons.cursor_icons_package }}"
+        - "{{ icons.desktop_icons_package }}"
         - hyprpicker
         - hyprshade
 

--- a/roles/hyprland/templates/autostart.conf.j2
+++ b/roles/hyprland/templates/autostart.conf.j2
@@ -11,6 +11,9 @@ exec-once = ags
 exec-once = gsettings set org.gnome.desktop.interface cursor-theme {{ icons.cursor_icons_theme }}
 exec-once = hyprctl setcursor {{ icons.cursor_icons_theme }} {{ icons.cursor_icons_size }}
 
+# Set up icon theme
+exec-once = gsettings set org.gnome.desktop.interface icon-theme {{ icons.desktop_icon_theme }}
+
 # initilize hyprpaper
 exec-once = hyprpaper
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It adds the configuration for setting system icon theme during
dotfiles installation process based on the configuration in the
group variables.

Another change I added after this makes use of `/etc/environment`
to set the desired cursor theme in greetd too.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I used Tela Circle Pink for consistency across other components of
the current AGS setup by default . The user will have to change the
icon theme themselves as I couldn't find an icon pack that would
adapt to system colors automatically.

Hyprland doesn't have its own `hyprctl` command for this and turns
out it actually pulls the icon theme configuration from GSettings
directly so just using `gsettings set` is enough in this case.

We don't have to add a corresponding file for `/etc/environment`
as every base GNU/Linux install has it.

#### Is it ready for merging, or does it need work?
Yes, it's ready for merging.

