### PR TITLE
Throw GNOME PolKit process to the background during startup

### DIFF
--- a/roles/hyprland/files/hypr/config/autostart.conf
+++ b/roles/hyprland/files/hypr/config/autostart.conf
@@ -8,7 +8,7 @@ exec-once = $hyprland-scripts/xdg.sh
 exec-once = hyprpm reload
 
 # Start polkit
-exec-once=/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
+exec-once=/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1&
 
 # Initilize ags
 exec-once = ags

--- a/roles/hyprland/templates/autostart.conf.j2
+++ b/roles/hyprland/templates/autostart.conf.j2
@@ -5,7 +5,7 @@
 exec-once = $hyprland-scripts/xdg.sh
 
 # Start polkit
-exec-once=/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
+exec-once=/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1&
 
 # Autostart plugins
 exec-once = hyprpm reload


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
GNOME PolKit is dying during Hyprland startup for some reason. This PR fixes that by having it launch as a background process.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
N/A

#### Is it ready for merging, or does it need work?
Yes, it's ready for merging.

