### PR TITLE
Stick to AGSv1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 1.1.5.1
+https://github.com/dianaw353/dotfiles/releases/tag/V1.1.5.1
+-----------------------------------------------------------
+**Fixes**
+- Stick to AGSv1.
+  - We have to do this as an interim until we port the current AGS config to v2.
+
 Version 1.1.5
 https://github.com/dianaw353/dotfiles/releases/tag/V1.1.5
 ---------------------------------------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -75,6 +75,16 @@ system:
       list:
         - https://github.com/virtcode/hypr-dynamic-cursors # dynamic-cursors
 
+  ags:
+    # Whether to use AGSv1.
+    #
+    # Don't set this to false if you can't deal with rewriting the entire stack for v2!
+    #
+    # See Aylur/ags#618 for more info.
+    #
+    # true or false
+    need_v1: true
+
 i18n:
   # Supplementary fonts
   fonts:

--- a/roles/ags/tasks/Archlinux.yml
+++ b/roles/ags/tasks/Archlinux.yml
@@ -1,14 +1,13 @@
 ---
 - name: Install Packages and Dependencies
   block:
-    - name: Install AGS AUR Packages | {{ ansible_distribution }}
+    - name: Install Common AGS AUR Packages | {{ ansible_distribution }}
       kewlfft.aur.aur:
         name: "{{ item }}"
         state: present
         use: "{{ pacman.aur_helper }}"
       become: false
       loop:
-        - aylurs-gtk-shell-git
         - bun-bin
         - matugen-bin
         - wayshot
@@ -34,3 +33,36 @@
         - swappy
         - greetd
         - cage
+
+    - name: Install AGSv2 | {{ ansible_distribution }}
+      kewlfft.aur.aur:
+        name: "{{ item }}"
+        state: present
+        use: "{{ pacman.aur_helper }}"
+      become: false
+      loop:
+        - aylurs-gtk-shell-git
+      when: system.ags.need_v1 is not defined or not system.ags.need_v1
+
+- name: Build and Install AGSv1
+  when: system.ags.need_v1 is defined and system.ags.need_v1
+  block:
+    - name: Build AGSv1
+      ansible.builtin.shell:
+        cmd: |
+          mkdir {{ ansible_user_dir }}/agsv1_rebuild
+          cd {{ ansible_user_dir }}/agsv1_rebuild
+          /usr/bin/curl -fsSL https://github.com/kotontrion/PKGBUILDS/raw/main/agsv1/PKGBUILD > PKGBUILD
+          makepkg -s
+      register: agsv1_build_outcome
+      changed_when: no
+      when: system.ags.need_v1 is defined and system.ags.need_v1
+
+    - name: Install Rebuilt AGSv1
+      community.general.pacman:
+        name: "{{ item }}"
+        state: present
+      become: true
+      loop:
+        - "{{ ansible_user_dir }}/agsv1_rebuild/agsv1-1.9.0-1-x86_64.pkg.tar.zst"
+      register: agsv1_install_outcome


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- Adds a new config to build AGSv1 using the PKGBUILD provided by the AUR packager themselves, set to true by default for now.
- Separates the original AGS installation step so we can avoid installing it for the time being.
- Increments the VERSION to 1.1.5.1.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
THIS MUST BE MERGED AND RELEASED AS QUICKLY AS POSSIBLE AS AGSv2 IS ALREADY ON THE AUR AS OF NOW!

#### Is it ready for merging, or does it need work?
Ready for merging. Passes the check mode by default.

